### PR TITLE
Update API, focus on immutability to improve performance + misc tweaks

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -26,11 +26,11 @@ Array [
 
 exports[`sql-query creates a simple sql statement 4`] = `undefined`;
 
-exports[`sql-query creates insert statement 1`] = `"INSERT INTO randoms VALUES $1"`;
+exports[`sql-query creates bunch of insert statements 1`] = `"INSERT INTO randoms VALUES $1"`;
 
-exports[`sql-query creates insert statement 2`] = `"INSERT INTO randoms VALUES ?"`;
+exports[`sql-query creates bunch of insert statements 2`] = `"INSERT INTO randoms VALUES ?"`;
 
-exports[`sql-query creates insert statement 3`] = `
+exports[`sql-query creates bunch of insert statements 3`] = `
 Array [
   Array [
     Array [
@@ -72,7 +72,65 @@ Array [
 ]
 `;
 
-exports[`sql-query creates insert statement 4`] = `undefined`;
+exports[`sql-query creates bunch of insert statements 4`] = `undefined`;
+
+exports[`sql-query creates insert statement which contains query inside of array of values 1`] = `"INSERT INTO randoms VALUES ($1,$2)"`;
+
+exports[`sql-query creates insert statement which contains query inside of array of values 2`] = `"INSERT INTO randoms VALUES (?,?)"`;
+
+exports[`sql-query creates insert statement which contains query inside of array of values 3`] = `
+Array [
+  Array [
+    Array [
+      0.1330345695292965,
+      0.3087555548059029,
+      0.15782168758438098,
+      0.8914307967523212,
+      0.6590624325544447,
+    ],
+    Array [
+      0.1330345695292965,
+      0.3087555548059029,
+      0.15782168758438098,
+      0.8914307967523212,
+      0.6590624325544447,
+    ],
+    Array [
+      0.1330345695292965,
+      0.3087555548059029,
+      0.15782168758438098,
+      0.8914307967523212,
+      0.6590624325544447,
+    ],
+    Array [
+      0.1330345695292965,
+      0.3087555548059029,
+      0.15782168758438098,
+      0.8914307967523212,
+      0.6590624325544447,
+    ],
+    Array [
+      0.1330345695292965,
+      0.3087555548059029,
+      0.15782168758438098,
+      0.8914307967523212,
+      0.6590624325544447,
+    ],
+  ],
+  Array [
+    Array [
+      0.15782168758438098,
+      0.15782168758438098,
+    ],
+    Array [
+      0.6590624325544447,
+      0.6590624325544447,
+    ],
+  ],
+]
+`;
+
+exports[`sql-query creates insert statement which contains query inside of array of values 4`] = `undefined`;
 
 exports[`sql-query creates insert statements using lazy evaluated values 1`] = `"INSERT INTO randoms VALUES ($1,$2,$3,$4,$5)"`;
 
@@ -89,25 +147,6 @@ Array [
 `;
 
 exports[`sql-query creates insert statements using lazy evaluated values 4`] = `undefined`;
-
-exports[`sql-query creates more complicated statement using set of values 1`] = `"SELECT * FROM cars WHERE name = ANY($1) and surname = $2 and age <= $3 LEFT INNER JOIN people ON (people.car_id = cars._id and people.age >= $4)"`;
-
-exports[`sql-query creates more complicated statement using set of values 2`] = `"SELECT * FROM cars WHERE name = ANY(?) and surname = ? and age <= ? LEFT INNER JOIN people ON (people.car_id = cars._id and people.age >= ?)"`;
-
-exports[`sql-query creates more complicated statement using set of values 3`] = `
-Array [
-  Array [
-    1,
-    2,
-    3,
-  ],
-  "Alex",
-  80,
-  18,
-]
-`;
-
-exports[`sql-query creates more complicated statement using set of values 4`] = `undefined`;
 
 exports[`sql-query creates named statement 1`] = `"      SELECT * FROM table    "`;
 
@@ -169,21 +208,65 @@ exports[`sql-query creates query with statements joined by "," 3`] = `Array []`;
 
 exports[`sql-query creates query with statements joined by "," 4`] = `undefined`;
 
+exports[`sql-query creates sql statement using set of values 1`] = `"SELECT * FROM cars WHERE name = ANY($1) and surname = $2 and age <= $3 LEFT INNER JOIN people ON (people.car_id = cars._id and people.age >= $4)"`;
+
+exports[`sql-query creates sql statement using set of values 2`] = `"SELECT * FROM cars WHERE name = ANY(?) and surname = ? and age <= ? LEFT INNER JOIN people ON (people.car_id = cars._id and people.age >= ?)"`;
+
+exports[`sql-query creates sql statement using set of values 3`] = `
+Array [
+  Array [
+    1,
+    2,
+    3,
+  ],
+  "Alex",
+  80,
+  18,
+]
+`;
+
+exports[`sql-query creates sql statement using set of values 4`] = `undefined`;
+
+exports[`sql-query creates statement using lazy evaluated queries and checks count of fn calls 1`] = `"INSERT INTO $1 VALUES ($2, $3, $4)"`;
+
+exports[`sql-query creates statement using lazy evaluated queries and checks count of fn calls 2`] = `"INSERT INTO ? VALUES (?, ?, ?)"`;
+
+exports[`sql-query creates statement using lazy evaluated queries and checks count of fn calls 3`] = `
+Array [
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+]
+`;
+
+exports[`sql-query creates statement using lazy evaluated queries and checks count of fn calls 4`] = `undefined`;
+
 exports[`sql-query imports modules 1`] = `
 SQLQuery {
-  Symbol(QUERIES): Array [],
-  Symbol(VALUES): Array [],
-  Symbol(DELIMITER): "",
+  Symbol(sql-template-builder/QUERIES): Array [],
+  Symbol(sql-template-builder/VALUES): Array [],
+  Symbol(sql-template-builder/DELIMITER): "",
+  Symbol(sql-template-builder/NAME): undefined,
+  Symbol(sql-template-builder/GET_QUERY_VALUES): [Function],
+  Symbol(sql-template-builder/GET_QUERY_STATEMENTS): [Function],
+  Symbol(sql-template-builder/GET_TEXT): [Function],
+  Symbol(sql-template-builder/GET_SQL): [Function],
 }
 `;
 
 exports[`sql-query imports modules 2`] = `
 SQLQuery {
-  Symbol(QUERIES): Array [
+  Symbol(sql-template-builder/QUERIES): Array [
     "SELECT * FROM table",
   ],
-  Symbol(VALUES): Array [],
-  Symbol(DELIMITER): "",
+  Symbol(sql-template-builder/VALUES): Array [],
+  Symbol(sql-template-builder/DELIMITER): "",
+  Symbol(sql-template-builder/NAME): undefined,
+  Symbol(sql-template-builder/GET_QUERY_VALUES): [Function],
+  Symbol(sql-template-builder/GET_QUERY_STATEMENTS): [Function],
+  Symbol(sql-template-builder/GET_TEXT): [Function],
+  Symbol(sql-template-builder/GET_SQL): [Function],
 }
 `;
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@ const sql = require("../src");
 
 const testQuery = (query, exclude = []) => {
   ["text", "sql", "values", "name"].forEach(
-    prop => !exclude.includes(prop) && expect(query[prop]).toMatchSnapshot()
+    (prop) => !exclude.includes(prop) && expect(query[prop]).toMatchSnapshot()
   );
   expect(query.toString()).toBe(query.text);
 };
@@ -12,55 +12,58 @@ describe("sql-query", () => {
     const statement = sql`SELECT * FROM cars where name = ${123}`;
     testQuery(statement);
   });
-  it("creates more complicated statement using set of values", () => {
+
+  it("creates sql statement using set of values", () => {
     const statement = sql`SELECT * FROM ${sql`cars`} WHERE name = ANY(${[
       1,
       2,
-      3
+      3,
     ]}) ${sql`and surname = ${"Alex"} ${sql`and age <= ${80} ${sql`LEFT INNER JOIN people ON (${sql`people.car_id = cars._id and people.age >= ${18}`})`}`}`}`;
     testQuery(statement);
   });
-  it("creates insert statement", () => {
+
+  it("creates bunch of insert statements", () => {
     const data = [
       [
         0.6181323459330601,
         0.5274565380505569,
         0.7000696258860464,
         0.7815711480320064,
-        0.9371433950915682
+        0.9371433950915682,
       ],
       [
         0.3650824402206174,
         0.1595414403296309,
         0.9293976539275104,
         0.037649011518704034,
-        0.41173798458754307
+        0.41173798458754307,
       ],
       [
         0.6930353425814768,
         0.7121006763795512,
         0.4057077621010592,
         0.4308763443801644,
-        0.32467250272048775
+        0.32467250272048775,
       ],
       [
         0.6897208158657151,
         0.22287760419345615,
         0.5273515054137508,
         0.7650702585633016,
-        0.16057079180642386
+        0.16057079180642386,
       ],
       [
         0.6675926745658798,
         0.8303484131711736,
         0.9148680662075892,
         0.6387881772297832,
-        0.33955563575442826
-      ]
+        0.33955563575442826,
+      ],
     ];
     const statement = sql`INSERT INTO randoms VALUES ${data}`;
     testQuery(statement);
   });
+
   it("creates nested query using rest parameters", () => {
     const data = [
       [
@@ -68,65 +71,69 @@ describe("sql-query", () => {
         0.3087555548059029,
         0.15782168758438098,
         0.8914307967523212,
-        0.6590624325544447
+        0.6590624325544447,
       ],
       [
         0.06506375788874474,
         0.36047481202714726,
         0.32332707855244647,
         0.2731640180512882,
-        0.6316953839372026
+        0.6316953839372026,
       ],
       [
         0.920950181599979,
         0.08854906115208117,
         0.47474283207068235,
         0.8391625554958557,
-        0.5373815478713315
+        0.5373815478713315,
       ],
       [
         0.737341390691238,
         0.171325936243528,
         0.19181998354398777,
         0.10584509459975844,
-        0.17729080067019432
+        0.17729080067019432,
       ],
       [
         0.030403041139161813,
         0.9916368534057693,
         0.6018355339802939,
         0.5183570252142247,
-        0.8927941295201514
-      ]
+        0.8927941295201514,
+      ],
     ];
     const statement = sql`INSERT INTO randoms VALUES ${sql(
-      ...data.map(v => sql`(${sql(...v)})`)
+      ...data.map((v) => sql`(${sql(...v)})`)
     )}`;
     testQuery(statement);
   });
+
   it("uses lazy evaluated statements", () => {
     const getName = () => "hey";
     testQuery(sql`SELECT * FROM people WHERE name = ${getName}`);
   });
+
   it("creates insert statements using lazy evaluated values", () => {
     const getName = () => sql`randoms`;
-    const getValue = query =>
+    const getValue = (query) =>
       [
         0.030403041139161813,
         0.9916368534057693,
         0.6018355339802939,
         0.5183570252142247,
-        0.8927941295201514
+        0.8927941295201514,
       ][data.indexOf(query)];
     const data = Array.from({ length: 5 }, () => sql`${getValue}`);
     const statement = sql`INSERT INTO ${getName} VALUES (${sql(...data)})`;
     testQuery(statement);
   });
+
   it('creates query with statements joined by ","', () => {
     const statements = [sql`a`, sql`b`, sql`c`, sql`d`];
     const statement = sql(...statements);
     testQuery(statement);
   });
+
   it("imports modules", () => {
     jest.resetModules();
     const createSQLTemplateQuery = require("../src");
@@ -135,11 +142,13 @@ describe("sql-query", () => {
     expect(defaulT).toBe(createSQLTemplateQuery);
     expect(raw("SELECT * FROM table")).toMatchSnapshot();
   });
+
   it('creates query with statements joined by "+"', () => {
     const statements = [sql`a`, sql`b`, sql`c`, sql`d`];
-    const statement = sql(statements).joinBy("+");
+    const statement = sql(...statements).joinBy("+");
     testQuery(statement);
   });
+
   it("creates named statement", () => {
     const name = "select_from_table";
     const statement = sql`
@@ -147,6 +156,36 @@ describe("sql-query", () => {
     `.setName(name);
     testQuery(statement);
   });
+
+  it("creates insert statement which contains query inside of array of values", () => {
+    const data = [
+      Array(5).fill([
+        0.1330345695292965,
+        0.3087555548059029,
+        0.15782168758438098,
+        0.8914307967523212,
+        0.6590624325544447,
+      ]),
+      sql`${() => [Array(2).fill(0.15782168758438098), Array(2).fill(0.6590624325544447)]}`,
+    ];
+
+    testQuery(sql`INSERT INTO randoms VALUES (${sql(...data)})`);
+  });
+
+  it("creates statement using lazy evaluated queries and checks count of fn calls", () => {
+    const relation = jest.fn();
+    const data = jest.fn();
+    const relationStatement = sql`${relation}`;
+    const innerStatement = sql`${sql`${data}`}`;
+
+    testQuery(
+      sql`INSERT INTO ${relationStatement} VALUES (${innerStatement}, ${innerStatement}, ${innerStatement})`
+    );
+    // `text`, `sql` and `values`
+    expect(relation).toBeCalledTimes(2);
+    expect(data).toBeCalledTimes(2);
+  })
+
   it("attemps to pass invalid values to SQLQuery constructor", () => {
     expect(() => new sql.SQLQuery(1, [], "")).toThrowErrorMatchingSnapshot();
     expect(() => new sql.SQLQuery([], 1, "")).toThrowErrorMatchingSnapshot();
@@ -154,17 +193,24 @@ describe("sql-query", () => {
     expect(() => {
       const query = new sql.SQLQuery();
       const sym = Object.getOwnPropertySymbols(Object.getPrototypeOf(query));
-      query[sym[4]]("", 0);
+      query[sym[2]]("", 0);
     }).toThrowErrorMatchingSnapshot();
     expect(() => {
       const query = new sql.SQLQuery();
       const sym = Object.getOwnPropertySymbols(Object.getPrototypeOf(query));
-      query[sym[4]]("!", 1);
+      query[sym[2]]("!", 1);
     }).toThrowErrorMatchingSnapshot();
   });
+
   it("attemps to set invalid values in query", () => {
     const query = sql`SELECT 1 from table where name = ${"Me"}`;
     expect(() => query.setName(0)).toThrowErrorMatchingSnapshot();
     expect(() => query.joinBy(0)).toThrowErrorMatchingSnapshot();
   });
+
+  it("doesnt create new object if name or delimiter equals to the old", () => {
+    const query = sql`SELECT 1 from table where name = ${"Me"}`.setName("test").joinBy("+");
+    expect(query.setName("test")).toBe(query);
+    expect(query.joinBy("+")).toBe(query);
+  })
 });

--- a/examples/pg.js
+++ b/examples/pg.js
@@ -1,14 +1,14 @@
 const pg = require("pg");
 const sql = require("../src");
 
-const pool = new pg.Pool();
+const pool = new pg.Pool({ host: "localhost", database: "postgres" });
 
 const tableName = sql`people`;
 
-const columns = [sql`name varchar,`, sql`age int2`];
+const columns = [sql`name varchar`, sql`age int2`];
 
 const createTableQuery = sql`
-  CREATE TABLE IF NOT EXISTS ${tableName}(${columns});
+  CREATE TABLE IF NOT EXISTS ${tableName}(${sql(...columns)});
 `;
 
 const data = [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Oleg Nosov <olegnosov1@gmail.com>",
   "name": "sql-template-builder",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "main": "./index.js",
   "description": "Complex SQL query builder",
   "keywords": [


### PR DESCRIPTION
API changes:

- `setName` and `joinBy` don't mutate current query but create new one instead

- Queries can't be placed inside of values array anymore. Now they should be always on top-level

```javascript
const queryArr = [sql`a`, sql`b`];
sql`${queryArr}` => sql`${sql(...queryArr)}`
```

- Better performance because of caching and immutability, so now you shouldn't mutate any values passed to query statement but instead recreate query when new values come

```javascript
const mutableArr = [1,2,3];
const immutableQuery = sql`INSERT INTO vals VALUES (${mutableArr})`;
immutableQuery.values; // => [[1,2,3]];
mutableArr.push(4);
immutableQuery.values; // => [[1,2,3]];
````
should become
```javascript
let arr = [1,2,3];
let query = sql`INSERT INTO vals VALUES (${arr})`;
query.values; // => [[1,2,3]];
arr = arr.concat(4);
query = sql`INSERT INTO vals VALUES (${arr})`;
query.values; // => [[1,2,3,4]];
```